### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hubidubi/herokuapp/security/code-scanning/1](https://github.com/hubidubi/herokuapp/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily checks out the code and builds it using Maven, so it only needs `contents: read` permissions. This ensures that the workflow has the least privileges necessary to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
